### PR TITLE
Adding a more informative error message for burning unknown token.

### DIFF
--- a/eosdactoken/eosdactoken.cpp
+++ b/eosdactoken/eosdactoken.cpp
@@ -138,7 +138,8 @@ void eosdactoken::burn(account_name from, asset quantity ) {
 
     auto sym = quantity.symbol.name();
     stats statstable( _self, sym );
-    const auto& st = statstable.get( sym );
+    const auto& st = statstable.find(sym);
+    eosio_assert( st != statstable.end(), "Attempting to burn a token unknown to this contract");
     eosio_assert( !st.transfer_locked, "Burn tokens on transferLocked token. The issuer must `unlock` first" );
     require_recipient( from );
 


### PR DESCRIPTION
Adding a more informative error message for burning unknown token than "unable to find key"