### PR TITLE
Fixed Ricardian clauses format.

### DIFF
--- a/eosdactoken/eosdactoken.abi
+++ b/eosdactoken/eosdactoken.abi
@@ -183,10 +183,12 @@
 		"key_types": ["uint64"]
 	}],
 	"ricardian_clauses": [{
-			"entire_agreement": "## ENTIRE AGREEMENT.\nThis contract contains the entire agreement of the parties, for all described actions, and there are no other promises or conditions in any other agreement whether oral or written concerning the subject matter of this Contract. This contract supersedes any prior written or oral agreements between the parties. "
+			"id": "entire_agreement",
+			"body": "## ENTIRE AGREEMENT.\nThis contract contains the entire agreement of the parties, for all described actions, and there are no other promises or conditions in any other agreement whether oral or written concerning the subject matter of this Contract. This contract supersedes any prior written or oral agreements between the parties. "
 		},
 		{
-			"binding_constitution": "## BINDING CONSTITUTION:\nAll the the action descibed in this contract are subject to the EOSDAC consitution as held at http://eosdac.io . This includes, but is not limited to membership terms and condiutions, dispute resolution and severability."
+			"id": "binding_constitution",
+			"body": "## BINDING CONSTITUTION:\nAll the the action descibed in this contract are subject to the EOSDAC consitution as held at http://eosdac.io . This includes, but is not limited to membership terms and condiutions, dispute resolution and severability."
 		}
 	],
 	"abi_extensions": []


### PR DESCRIPTION
Fixed the format of the clauses to have the keys `id` and `body` for each field.